### PR TITLE
Fix Undefined property: stdClass::$rating

### DIFF
--- a/layouts/joomla/apps/extensions_imagegrid.php
+++ b/layouts/joomla/apps/extensions_imagegrid.php
@@ -75,7 +75,8 @@ $layouts = array('grid', 'list');
 				// The single extension box is loaded using the JLayout
 				$i = 0;
 				foreach ($displayData['extensions'] as $extension) :
-					$ratingwidth = round(70 * ($extension->rating / 5));
+					// @todo Looks unsed maybe removing the following line? 
+					// $ratingwidth = round(70 * ($extension->rating / 5));
 					if ($i != 0 && $i%$extensions_perrow == 0 && $layout != 'list') { 
 			?>
 			</ul>	


### PR DESCRIPTION
Access the default view: see the notices.
Notice: Undefined property: stdClass::$rating in JRoot\layouts\joomla\apps\extensions_imagegrid.php on line 78
